### PR TITLE
Fixing typo in quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -30,7 +30,7 @@ Quickstart
             /fcm/v1/devices/{id}/
 
 
-#. Configure `django-dcm` in your ``settings.py`` file::
+#. Configure `django-fcm` in your ``settings.py`` file::
 
       INSTALLED_APPS = [
           # ...


### PR DESCRIPTION
Renaming from `django-dcm` to `django-fcm` in the quickstart.rst.