### PR TITLE
Extend Device model with no issues

### DIFF
--- a/fcm/admin.py
+++ b/fcm/admin.py
@@ -11,7 +11,7 @@ Device = get_device_model()
 
 
 class DeviceAdmin(admin.ModelAdmin):
-    list_display = ['dev_id', 'name', 'is_active']
+    list_display = [f.name for f in Device._meta.fields if f.name != "id" if f.name != "reg_id"]
     search_fields = ('dev_id', 'name')
     list_filter = ['is_active']
     readonly_fields = ('dev_id', 'reg_id')

--- a/fcm/serializers.py
+++ b/fcm/serializers.py
@@ -6,4 +6,4 @@ Device = get_device_model()
 class DeviceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Device
-        fields = ('dev_id', 'reg_id', 'name', 'is_active')
+        fields = '__all__'


### PR DESCRIPTION
This addresses the following issue: https://github.com/Chitrank-Dixit/django-fcm/issues/27

When you extend the Device model, the fields of the corresponding DeviceSerializer [remain static](https://github.com/Chitrank-Dixit/django-fcm/blob/master/fcm/serializers.py#L9), not reflecting those of the custom `FCM_DEVICE_MODEL`. This causes errors when attempting to register a new device, since any added fields are not passed to Device.

The changes in this PR make the fields of `DeviceSerializer` and `DeviceAdmin` dynamic, adapting to whichever model is used for `FCM_DEVICE_MODEL`.