### PR TITLE
Properly grab FCM_APIKEY and FCM_MAX_RECIPIENTS from settings

### DIFF
--- a/fcm/admin.py
+++ b/fcm/admin.py
@@ -11,7 +11,7 @@ Device = get_device_model()
 
 
 class DeviceAdmin(admin.ModelAdmin):
-    list_display = ['dev_id', 'name', 'is_active']
+    list_display = [f.name for f in Device._meta.fields if f.name != "id" if f.name != "reg_id"]
     search_fields = ('dev_id', 'name')
     list_filter = ['is_active']
     readonly_fields = ('dev_id', 'reg_id')

--- a/fcm/serializers.py
+++ b/fcm/serializers.py
@@ -6,4 +6,4 @@ Device = get_device_model()
 class DeviceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Device
-        fields = ('dev_id', 'reg_id', 'name', 'is_active')
+        fields = '__all__'

--- a/fcm/utils.py
+++ b/fcm/utils.py
@@ -85,6 +85,13 @@ class BaseFCMMessage(object):
             print("Using default settings.FCM_MAX_RECIPIENTS value 1. Change it via settings")
             self.max_recipients = 1
 
+    def _chunks(self, items, limit):
+        """
+            Yield successive chunks from list \a items with a minimum size \a limit
+        """
+        for i in range(0, len(items), limit):
+            yield items[i:i + limit]
+
     def send(self, data, notification=None, registration_ids=None, **kwargs):
         if not isinstance(data, dict):
             data = {'msg': data}

--- a/fcm/utils.py
+++ b/fcm/utils.py
@@ -64,6 +64,27 @@ class NotificationMessage(object):
 
 class BaseFCMMessage(object):
 
+    def __init__(self):
+        """
+        you will not reach to test self.api_key if it is not set in settings...
+        """
+        try:
+            self.api_key = settings.FCM_APIKEY
+        except AttributeError:
+            raise ImproperlyConfigured(
+                "You haven't set the 'FCM_APIKEY' setting yet.")
+
+        """
+        accessing settings.FCM_MAX_RECIPIENTS if not set
+        will crash the app, it can be set to 1 by default
+        """
+        try:
+            self.max_recipients = settings.FCM_MAX_RECIPIENTS
+        except AttributeError:
+            # some kind of warning would be nice
+            print("Using default settings.FCM_MAX_RECIPIENTS value 1. Change it via settings")
+            self.max_recipients = 1
+
     def send(self, data, notification=None, registration_ids=None, **kwargs):
         if not isinstance(data, dict):
             data = {'msg': data}


### PR DESCRIPTION
I believe @Renzo04 accidentally removed the `__init__` method from `FCMMessage` when submitting https://github.com/Chitrank-Dixit/django-fcm/pull/36.

See here:
https://github.com/Chitrank-Dixit/django-fcm/pull/36/commits/efd8a6f40c68b0f249d1863bcdde90b0591bd44a#r106833311