### PR TITLE
updated deprecated import of reverse

### DIFF
--- a/fcm/management/commands/fcm_urls.py
+++ b/fcm/management/commands/fcm_urls.py
@@ -1,5 +1,5 @@
 from django.core.management.base import BaseCommand
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from fcm.views import DeviceViewSet
 
 


### PR DESCRIPTION
"from django.core.urlresolvers import reverse" is deprecated , now instead of that "from django.urls import reverse" is used